### PR TITLE
Refactor GAN tooling into installable package with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,43 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gan-nomenclature"
+version = "0.1.0"
+description = "Generate bacterial nomenclature Latin names using a combinatorial approach."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { file = "LICENSE" }
+authors = [
+    { name = "GAN contributors" }
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "pandas>=1.3",
+    "openpyxl",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+
+[project.scripts]
+"gan-genus" = "gan_nomenclature.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/telatin/gan"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"gan_nomenclature" = ["templates/*.template"]

--- a/src/gan_nomenclature/__init__.py
+++ b/src/gan_nomenclature/__init__.py
@@ -1,0 +1,25 @@
+"""GAN nomenclature package."""
+
+from .generator import (
+    GenerationResult,
+    GeneratedName,
+    combine_etymology,
+    combine_roots,
+    generate_entries,
+    generate_outputs,
+    join_two_roots,
+)
+from .io import read_root_table
+
+__all__ = [
+    "GenerationResult",
+    "GeneratedName",
+    "combine_etymology",
+    "combine_roots",
+    "generate_entries",
+    "generate_outputs",
+    "join_two_roots",
+    "read_root_table",
+]
+
+__version__ = "0.1.0"

--- a/src/gan_nomenclature/cli.py
+++ b/src/gan_nomenclature/cli.py
@@ -1,0 +1,75 @@
+"""Command line interface for GAN nomenclature."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List
+
+from .generator import generate_outputs
+from .io import read_root_table
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate bacterial genera with Excel input.",
+    )
+    parser.add_argument("-1", "--first", required=True, help='First Excel file in "GAN" format')
+    parser.add_argument("-2", "--second", required=True, help='Second Excel file in "GAN" format')
+    parser.add_argument("-3", "--third", help='Third Excel file in "GAN" format')
+    parser.add_argument("-o", "--outdir", required=True, help="Output directory")
+    parser.add_argument("-p", "--prefix", default="gan", help="Output basename [default: 'gan']")
+    parser.add_argument(
+        "-c",
+        "--connector",
+        default="of",
+        help="String connecting the explanatory strings [default: 'of']",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Increase output verbosity",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    first_table = read_root_table(args.first)
+    second_table = read_root_table(args.second)
+    third_table = read_root_table(args.third) if args.third else None
+
+    filenames = [Path(args.first).name, Path(args.second).name]
+    if args.third:
+        filenames.append(Path(args.third).name)
+    else:
+        filenames.append("(not provided)")
+
+    result = generate_outputs(
+        first_table,
+        second_table,
+        third_table,
+        connector=args.connector,
+        filenames=filenames,
+    )
+
+    base = args.prefix
+    (outdir / f"{base}.json").write_text(result.to_json(), encoding="utf-8")
+    (outdir / f"{base}.html").write_text(result.html, encoding="utf-8")
+    (outdir / f"{base}.tex").write_text(result.latex, encoding="utf-8")
+
+    if args.verbose:
+        print(f"Generated {len(result.entries)} names.")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/gan_nomenclature/generator.py
+++ b/src/gan_nomenclature/generator.py
@@ -1,0 +1,308 @@
+"""Core generation logic for GAN nomenclature."""
+
+from __future__ import annotations
+
+import itertools
+import json
+import re
+from dataclasses import dataclass
+from importlib import resources
+from string import Template
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import pandas as pd
+
+PROTECTED_SUFFIXES = (
+    "bio",
+    "geo",
+    "neo",
+    "mega",
+    "micro",
+    "allo",
+    "amphi",
+    "extra",
+    "hetero",
+    "iso",
+    "iuxta",
+    "meso",
+    "peri",
+    "quasi",
+    "ultra",
+)
+
+VOWELS = set("aeiouAEIOU")
+
+
+@dataclass(frozen=True)
+class GeneratedName:
+    """Representation of a generated bacterial name."""
+
+    name: str
+    triplet: Tuple[str, ...]
+    etymology_text: str
+    etymology_html: str
+    tokens: List[Tuple[str, str]]
+
+
+@dataclass
+class GenerationResult:
+    """Container for rendered outputs."""
+
+    entries: List[GeneratedName]
+    html: str
+    latex: str
+    json_data: List[dict]
+
+    def to_json(self, **kwargs) -> str:
+        """Return the JSON serialisation of the generated words."""
+
+        kwargs.setdefault("indent", 4)
+        kwargs.setdefault("sort_keys", True)
+        return json.dumps(self.json_data, **kwargs)
+
+
+def _is_vowel(letter: str) -> bool:
+    if not letter:
+        return False
+    if len(letter) != 1:
+        raise ValueError(f"Expected a single character, received {letter!r}.")
+    return letter in VOWELS
+
+
+def _strip_digits(value: str) -> str:
+    return "".join(ch for ch in value if not ch.isdigit())
+
+
+def join_two_roots(first: str, second: str) -> str:
+    """Join two roots according to GAN rules."""
+
+    first = _strip_digits(first)
+    second = _strip_digits(second)
+
+    if not first:
+        return second
+    if not second:
+        return first
+
+    if first.endswith(PROTECTED_SUFFIXES):
+        return first + second
+
+    if _is_vowel(first[-1]) and _is_vowel(second[0]):
+        return first[:-1] + second
+
+    return first + second
+
+
+def combine_roots(roots: Sequence[str]) -> str:
+    """Combine two or three roots into a single capitalised word."""
+
+    if not roots:
+        raise ValueError("No roots provided")
+
+    iterator = iter(roots)
+    word = next(iterator)
+    for part in iterator:
+        word = join_two_roots(word, part)
+
+    return word.capitalize()
+
+
+def _value_from_table(table: pd.DataFrame, column: str, key: str) -> Optional[str]:
+    if column not in table.columns:
+        return None
+    value = table[column].get(key)
+    if pd.isna(value):
+        return None
+    return str(value)
+
+
+def combine_etymology(
+    triplet: Sequence[str],
+    tables: Sequence[pd.DataFrame],
+    *,
+    connector: str = "of",
+) -> Tuple[str, str, List[Tuple[str, str]]]:
+    """Combine metadata from all roots into textual representations."""
+
+    etymology_html_parts: List[str] = []
+    tokens: List[Tuple[str, str]] = []
+
+    for index, key in enumerate(triplet):
+        table = tables[index]
+        for column in ("Language", "Gender", "Part", "Word", "Definition"):
+            value = _value_from_table(table, column, key)
+            if value is None:
+                continue
+
+            if column in {"Language", "Gender", "Part"}:
+                etymology_html_parts.append(
+                    f'<span class="glossary">{value}</span>'
+                )
+                tokens.append(("glossary", value))
+            elif column == "Word":
+                etymology_html_parts.append(f"<em>{value}</em>,")
+                tokens.append(("italic", value))
+                tokens.append(("separator", ","))
+            else:
+                etymology_html_parts.append(value)
+                tokens.append(("plain", value))
+
+            if column != "Definition":
+                etymology_html_parts.append("&nbsp;")
+                tokens.append(("separator", " "))
+
+        etymology_html_parts.append("; ")
+        tokens.append(("separator", "; "))
+
+    explanations: List[str] = []
+    for index, key in enumerate(triplet):
+        explanation = _value_from_table(tables[index], "Explanation", key)
+        if explanation:
+            explanations.append(explanation)
+
+    if explanations:
+        hint = f" {connector} ".join(explanations)
+    else:
+        hint = ""
+
+    hint = re.sub(rf"\s*{re.escape(connector)}\s*$", "", hint).strip()
+
+    tokens.append(("combined", hint))
+
+    return hint, "".join(etymology_html_parts), tokens
+
+
+def generate_entries(
+    tables: Sequence[pd.DataFrame],
+    *,
+    connector: str = "of",
+) -> List[GeneratedName]:
+    """Generate names for all combinations of the provided tables."""
+
+    iterables = [table.index.tolist() for table in tables]
+    entries: List[GeneratedName] = []
+
+    for triplet in itertools.product(*iterables):
+        word = combine_roots(triplet)
+        hint, html, tokens = combine_etymology(triplet, tables, connector=connector)
+        entries.append(
+            GeneratedName(
+                name=word,
+                triplet=tuple(triplet),
+                etymology_text=hint,
+                etymology_html=html,
+                tokens=tokens,
+            )
+        )
+
+    return entries
+
+
+def _load_template(filename: str) -> Template:
+    data = resources.files("gan_nomenclature.templates").joinpath(filename).read_text(
+        encoding="utf-8"
+    )
+    return Template(data)
+
+
+def _build_html_list(entries: Sequence[GeneratedName]) -> str:
+    blocks = []
+    for entry in entries:
+        blocks.append(
+            "<div><p><h3>{name}</h3>\n"
+            "<strong>Etymology:</strong> {etymology}<em>{name}</em>: {hint}.</p></div>\n\n".format(
+                name=entry.name,
+                etymology=entry.etymology_html,
+                hint=entry.etymology_text,
+            )
+        )
+    return "".join(blocks)
+
+
+def _build_latex_list(entries: Sequence[GeneratedName]) -> str:
+    parts: List[str] = []
+
+    for entry in entries:
+        row = [f"\\textbf{{{entry.name}}} --- "]
+        for kind, value in entry.tokens:
+            if kind == "italic":
+                row.append(f"\\textit{{{value}}}")
+            elif kind == "glossary":
+                row.append(f"\\dashuline{{{value}}}")
+            elif kind == "combined":
+                if value:
+                    row.append(f"\\textit{{{entry.name}}}: {value}. ")
+            else:
+                row.append(value)
+        row.append("\n\n")
+        parts.append("".join(row))
+
+    latex_list = "".join(parts)
+    latex_list = latex_list.replace("_", "\\_")
+    latex_list = re.sub(
+        r"existing\s+genus\s+(\w+)",
+        r"existing genus \\textit{\1}",
+        latex_list,
+    )
+    latex_list = re.sub(
+        r"existing\s+species\s+(\w+\s+\w+)",
+        r"existing genus \\textit{\1}",
+        latex_list,
+    )
+    return latex_list
+
+
+def generate_outputs(
+    first: pd.DataFrame,
+    second: pd.DataFrame,
+    third: Optional[pd.DataFrame] = None,
+    *,
+    connector: str = "of",
+    filenames: Optional[Sequence[str]] = None,
+) -> GenerationResult:
+    """Generate all outputs for the provided root tables."""
+
+    tables: List[pd.DataFrame] = [first, second]
+    if third is not None:
+        tables.append(third)
+
+    entries = generate_entries(tables, connector=connector)
+    json_data = [{entry.name: entry.tokens} for entry in entries]
+
+    html_template = _load_template("html.template")
+    latex_template = _load_template("latex.template")
+
+    filename1 = filenames[0] if filenames and len(filenames) > 0 else "first"
+    filename2 = filenames[1] if filenames and len(filenames) > 1 else "second"
+    if third is not None:
+        filename3 = filenames[2] if filenames and len(filenames) > 2 else "third"
+        count3 = len(third.index)
+    else:
+        filename3 = (
+            filenames[2] if filenames and len(filenames) > 2 else "(not provided)"
+        )
+        count3 = 0
+
+    html_output = html_template.safe_substitute(
+        total=len(entries),
+        filename1=filename1,
+        filename2=filename2,
+        filename3=filename3,
+        count1=len(first.index),
+        count2=len(second.index),
+        count3=count3,
+        list=_build_html_list(entries),
+    )
+
+    latex_output = latex_template.safe_substitute(
+        count1=len(first.index),
+        count2=len(second.index),
+        count3=count3,
+        filename1=filename1.replace("_", "{\\_}"),
+        filename2=filename2.replace("_", "{\\_}"),
+        filename3=filename3.replace("_", "{\\_}"),
+        list=_build_latex_list(entries),
+        roots="\\textit{Not implemented in the current version.}",
+    )
+
+    return GenerationResult(entries=entries, html=html_output, latex=latex_output, json_data=json_data)

--- a/src/gan_nomenclature/io.py
+++ b/src/gan_nomenclature/io.py
@@ -1,0 +1,58 @@
+"""Input helpers for GAN nomenclature."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+import warnings
+
+import pandas as pd
+
+PathLike = Union[str, Path]
+
+REQUIRED_COLUMNS = ["Language", "Gender"]
+OPTIONAL_COLUMNS = ["Part", "Definition", "Explanation"]
+
+
+def _strip_series(series: pd.Series) -> pd.Series:
+    return series.apply(lambda value: value.strip() if isinstance(value, str) else value)
+
+
+def read_root_table(filename: PathLike) -> pd.DataFrame:
+    """Read a root table from an Excel workbook.
+
+    Parameters
+    ----------
+    filename:
+        Path to an Excel workbook that contains a sheet with a ``Root`` column.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Table indexed by the values in the ``Root`` column.
+
+    Raises
+    ------
+    ValueError
+        If one of the required columns is not available.
+    """
+
+    table = pd.read_excel(filename, sheet_name=0, header=0, index_col="Root")
+
+    for column in REQUIRED_COLUMNS:
+        if column not in table.columns:
+            raise ValueError(
+                f"Required column \"{column}\" not found in the Excel file \"{filename}\"."
+            )
+        table[column] = _strip_series(table[column])
+
+    for column in OPTIONAL_COLUMNS:
+        if column not in table.columns:
+            warnings.warn(
+                f"Suggested column \"{column}\" not found in the Excel file \"{filename}\".",
+                stacklevel=2,
+            )
+        else:
+            table[column] = _strip_series(table[column])
+
+    return table

--- a/src/gan_nomenclature/templates/html.template
+++ b/src/gan_nomenclature/templates/html.template
@@ -1,0 +1,50 @@
+<html>
+<!-- Generated with GAN, https://github.com/telatin/gan/ -->
+<head>
+<meta charset="utf-8" />
+    <style>
+    <!--
+        * {
+            font-family: Georgia, "Times New Roman", Times, serif;
+        }
+
+        h3 {
+            color: brown;
+            font-style: italic;
+            padding: 0px;
+            margin: 0px; margin-bottom: 0.5em;
+            margin-top: 1.6em;
+        }
+
+        .glossary {
+            border-bottom: 1px dotted;
+        }
+
+        .def  {
+            font-size: 1.1em;
+            line-height: 220%;
+        }
+        #page {
+            width: 80%;
+            margin: 0 auto 0 auto;
+        }
+    -->
+    </style>
+</head>
+<body>
+<div id=\"page\">
+    <h1>GAN Genera</h1>
+
+$total genera produced from:
+<ul>
+             <li><em>First table</em>:  $filename1 ($count1)</li>
+             <li><em>Second table</em>: $filename2 ($count2)</li>
+             <li><em>Third table</em>:  $filename3 ($count3)</li>
+</ul>
+
+   $list
+
+
+
+</div>
+</html>

--- a/src/gan_nomenclature/templates/latex.template
+++ b/src/gan_nomenclature/templates/latex.template
@@ -1,0 +1,31 @@
+%!TEX TS-program = pdflatex
+%!TEX TS-options = -shell-escape
+% Author: Phil Steinhorst, p.st@wwu.de
+% https://gitlab.com/phist91/latex-templates
+% Generated with GAN, https://github.com/telatin/gan/
+
+\newcommand{\obenlinks}{GAN (the Great Automatic Nomenclator)}
+
+\input{config.tex}
+\usepackage[normalem]{ulem}
+
+
+\begin{document}
+\begin{center}
+  \begin{tabular}{|rlp{4cm}rl|}
+  \hline
+   \textbf{First file:}  & $count1 roots & $filename1 & & \\
+   \textbf{Second File:} & $count2 roots & $filename2 & & \\
+   \textbf{Third file:}  & $count3 roots & $filename3 & & \\ \hline
+\end{tabular}
+\end{center}
+
+\section*{List of genera}
+
+$list
+
+\section*{List of roots}
+
+$roots
+
+\end{document}

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,103 @@
+import json
+
+import pandas as pd
+
+from gan_nomenclature.generator import generate_entries, generate_outputs
+
+
+PREFIX_ROWS = [
+    {
+        "Root": "lacto",
+        "Language": "L.",
+        "Gender": "masc.",
+        "Part": "n.",
+        "Word": "lac",
+        "Definition": "milk",
+        "Explanation": "milk",
+    },
+    {
+        "Root": "aero",
+        "Language": "Gr.",
+        "Gender": "masc.",
+        "Part": "n.",
+        "Word": "aer",
+        "Definition": "air",
+        "Explanation": "air",
+    },
+]
+
+MID_ROWS = [
+    {
+        "Root": "cola",
+        "Language": "N.L.",
+        "Gender": "fem.",
+        "Part": "n.",
+        "Word": "cola",
+        "Definition": "dweller",
+        "Explanation": "dweller",
+    }
+]
+
+SUFFIX_ROWS = [
+    {
+        "Root": "ensis",
+        "Language": "L.",
+        "Gender": "masc.",
+        "Part": "adj.",
+        "Word": "ensis",
+        "Definition": "from a place",
+        "Explanation": "Example",
+    }
+]
+
+
+def make_table(rows):
+    return pd.DataFrame(rows).set_index("Root")
+
+
+def test_generate_entries_three_tables():
+    prefix = make_table(PREFIX_ROWS)
+    mid = make_table(MID_ROWS)
+    suffix = make_table(SUFFIX_ROWS)
+
+    entries = generate_entries([prefix, mid, suffix], connector="of")
+
+    assert len(entries) == 2
+    assert entries[0].name == "Lactocolensis"
+    assert entries[0].etymology_text == "milk of dweller of Example"
+    assert ("combined", "milk of dweller of Example") in entries[0].tokens
+
+
+def test_generate_outputs_rendering():
+    prefix = make_table(PREFIX_ROWS)
+    mid = make_table(MID_ROWS)
+    suffix = make_table(SUFFIX_ROWS)
+
+    result = generate_outputs(
+        prefix,
+        mid,
+        suffix,
+        connector="of",
+        filenames=["table1.xlsx", "table2.xlsx", "table3.xlsx"],
+    )
+
+    assert "<h3>Lactocolensis</h3>" in result.html
+    assert "\\textbf{Lactocolensis}" in result.latex
+
+    payload = json.loads(result.to_json())
+    assert payload[0]["Lactocolensis"][-1] == ["combined", "milk of dweller of Example"]
+
+
+def test_generate_outputs_without_suffix():
+    prefix = make_table(PREFIX_ROWS[:1])
+    mid = make_table(MID_ROWS)
+
+    result = generate_outputs(
+        prefix,
+        mid,
+        connector="of",
+        filenames=["table1.xlsx", "table2.xlsx", "(not provided)"],
+    )
+
+    assert "(not provided)" in result.html
+    assert len(result.entries) == 1

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import pytest
+
+from gan_nomenclature.io import read_root_table
+
+
+def test_read_root_table_roundtrip(tmp_path):
+    df = pd.DataFrame(
+        [
+            {
+                "Root": "alpha",
+                "Language": "L.",
+                "Gender": "masc.",
+                "Part": "n.",
+                "Word": "alpha",
+                "Definition": "first",
+                "Explanation": "first",
+            }
+        ]
+    ).set_index("Root")
+
+    path = tmp_path / "table.xlsx"
+    df.to_excel(path)
+
+    table = read_root_table(path)
+
+    assert list(table.index) == ["alpha"]
+    assert table.loc["alpha", "Language"] == "L."
+
+
+def test_read_root_table_missing_column(tmp_path):
+    df = pd.DataFrame(
+        [
+            {
+                "Root": "alpha",
+                "Language": "L.",
+            }
+        ]
+    ).set_index("Root")
+
+    path = tmp_path / "table.xlsx"
+    df.to_excel(path)
+
+    with pytest.raises(ValueError):
+        read_root_table(path)

--- a/tests/test_roots.py
+++ b/tests/test_roots.py
@@ -1,0 +1,13 @@
+from gan_nomenclature.generator import combine_roots, join_two_roots
+
+
+def test_join_two_roots_protected_suffix():
+    assert join_two_roots("micro", "aero") == "microaero"
+
+
+def test_join_two_roots_vowel_collision():
+    assert join_two_roots("hydro", "aero") == "hydraero"
+
+
+def test_combine_roots_capitalisation():
+    assert combine_roots(("micro", "spora")) == "Microspora"


### PR DESCRIPTION
## Summary
- package the project with a pyproject-based configuration and expose a gan-genus console script
- refactor the nomenclature generator into importable modules with bundled templates
- add pytest-based unit tests and a GitHub Actions workflow to run them

## Testing
- PYTHONPATH=src pytest *(fails: pandas dependency unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ff262ababc8330850ccfc3fed8a12d